### PR TITLE
Fix Currency window label

### DIFF
--- a/Editor/Windows/CurrencyEditorWindow.cs
+++ b/Editor/Windows/CurrencyEditorWindow.cs
@@ -5,7 +5,7 @@ namespace UnityEditor.GameUtils
 {
     public class CurrencyEditorWindow : GenericAssetEditorWindow<CurrencyData>
     {
-        [MenuItem(Constant.MENU_NAME + "Material Editor")]
+        [MenuItem(Constant.MENU_NAME + "Currency Editor")]
         public static void ShowWindow()
         {
             var window = GetWindow<CurrencyEditorWindow>();


### PR DESCRIPTION
## Summary
- rename the Currency editor menu item to match window title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fb652b6588324921aae4ac4a1c5c8