### PR TITLE
Adjust tag lookup with TagInfo name check

### DIFF
--- a/Runtime/Tag Manager/TagManager.cs
+++ b/Runtime/Tag Manager/TagManager.cs
@@ -46,7 +46,7 @@ namespace GameUtils
         {
             foreach (var kvp in _values)
             {
-                if (kvp.Value.Value > 0)
+                if (kvp.Value.Name == typeof(T).Name && kvp.Value.Value > 0)
                 {
                     return true;
                 }


### PR DESCRIPTION
## Summary
- Ensure `HasTag<T>` verifies tag `Name` matches the `GameTag` type

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68948e3b3b30832482773028fee330ff