### PR TITLE
Fix Y-axis projectile trajectory values

### DIFF
--- a/Runtime/Projectiles/Projectile2D.cs
+++ b/Runtime/Projectiles/Projectile2D.cs
@@ -133,7 +133,9 @@ namespace GameUtils
             float nextYNormalized = _trajectoryCurve.Evaluate(nextXNormalized);
             float nextYCorrectionNormalized = _axisCorrectCurve.Evaluate(nextXNormalized);
             float nextYCorrectionAbsolute = nextYCorrectionNormalized * _trajectoryRange.y;
-            float nextY = _trajectoryStartPoint.y + nextYNormalized * _trajectoryMaxRelativeHeight + nextYCorrectionAbsolute;
+            _nextYTrajectoryPosition = nextYNormalized * _trajectoryMaxRelativeHeight;
+            _nextPositionYCorrectionAbsolute = nextYCorrectionAbsolute;
+            float nextY = _trajectoryStartPoint.y + _nextYTrajectoryPosition + _nextPositionYCorrectionAbsolute;
 
             //
             Vector3 newPos = new(nextX, nextY, 0);


### PR DESCRIPTION
## Summary
- correct Y-axis trajectory and correction values in Projectile2D so shadow positioning receives proper values

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898ad2ed2d083248b7a24ccaee98cea