### PR TITLE
feat: add generic setting binder

### DIFF
--- a/Runtime/UI/SettingBinder.cs
+++ b/Runtime/UI/SettingBinder.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+namespace GameUtils
+{
+    /// <summary>
+    /// Generic binder that synchronizes a <see cref="BaseSettingData{T}"/> with a UI component.
+    /// Derived classes must implement how to read/write values to the specific UI element.
+    /// </summary>
+    /// <typeparam name="T">Type of the setting value.</typeparam>
+    /// <typeparam name="TUI">Type of the UI component.</typeparam>
+    public abstract class SettingBinder<T, TUI> : MonoBehaviour where TUI : Component
+    {
+        [SerializeField] protected BaseSettingData<T> _data;
+        [SerializeField] protected TUI _uiComponent;
+
+        //
+        protected virtual void OnEnable()
+        {
+            if (_data != null)
+            {
+                _data.OnValueChanged += SetUIValue;
+            }
+
+            if (_uiComponent != null)
+            {
+                AddUIListener();
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (_data != null)
+            {
+                _data.OnValueChanged -= SetUIValue;
+            }
+
+            if (_uiComponent != null)
+            {
+                RemoveUIListener();
+            }
+        }
+
+        protected virtual void Start()
+        {
+            if (_data != null)
+            {
+                SetUIValue(_data.CurrentValue);
+            }
+        }
+
+        /// <summary>
+        /// Subscribe to UI change events.
+        /// Derived classes should link <see cref="OnUIValueChanged"/> to the UI callback.
+        /// </summary>
+        protected abstract void AddUIListener();
+
+        /// <summary>
+        /// Unsubscribe from UI change events.
+        /// </summary>
+        protected abstract void RemoveUIListener();
+
+        /// <summary>
+        /// Set the UI component to display the provided value.
+        /// </summary>
+        protected abstract void SetUIValue(T value);
+
+        /// <summary>
+        /// Retrieve the current value from the UI component.
+        /// </summary>
+        protected abstract T GetUIValue();
+
+        /// <summary>
+        /// Called when the UI component value changes.
+        /// Updates the underlying setting data with the current UI value.
+        /// </summary>
+        protected void OnUIValueChanged()
+        {
+            if (_data != null)
+            {
+                _data.SetValue(GetUIValue());
+            }
+        }
+    }
+}

--- a/Runtime/UI/SettingBinder.cs.meta
+++ b/Runtime/UI/SettingBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f39ecd3e4704693a8e2763b56837bff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add generic SettingBinder to sync BaseSettingData with UI components

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - cannot install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a216cee6a88324a2d7371f72bfd427