### PR TITLE
feat: set default execution order for achievement manager

### DIFF
--- a/Runtime/Achievements/AchievementManager.cs
+++ b/Runtime/Achievements/AchievementManager.cs
@@ -8,6 +8,7 @@ namespace GameUtils
     /// <summary>
     /// Manages achievement data and runtime instances.
     /// </summary>
+    [DefaultExecutionOrder(-100)]
     public class AchievementManager : GenericDataManager<AchievementManager, AchievementData>
     {
         private readonly Dictionary<string, RuntimeAchievement> _runtimeAchievements = new();


### PR DESCRIPTION
## Summary
- ensure `AchievementManager` wakes before other systems by adding `[DefaultExecutionOrder(-100)]`

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f362c0bc83248bfef16604902d76