### PR TITLE
Initialize EventManager earlier

### DIFF
--- a/Runtime/Events/EventManager.cs
+++ b/Runtime/Events/EventManager.cs
@@ -4,6 +4,7 @@ using UnityEngine.Events;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(-50)]
     public class EventManager : Singleton<EventManager>, ILoggable
     {
         [SerializeField] private bool _logEnabled = true;


### PR DESCRIPTION
## Summary
- initialize `EventManager` before other scripts using `DefaultExecutionOrder(-50)`

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6f360fd088324b715bedc0171f5ae