### PR TITLE
feat: expand tag manager functionality

### DIFF
--- a/Runtime/Tag Manager/README.md
+++ b/Runtime/Tag Manager/README.md
@@ -15,6 +15,12 @@ Questa cartella contiene un semplice sistema di gestione dei tag utilizzabile ne
 - `Dictionary<string, TagInfo> GetMap()` – ottiene l'intero dizionario di tag e relative informazioni.
 - `TryGetValue(string tag, out TagInfo info)` – recupera le informazioni del tag tramite la stringa `ID`.
 - `Clear()` – rimuove tutte le associazioni registrate.
+- `HasAny(params GameTag[] tags)` – verifica se almeno uno dei tag specificati è presente.
+- `HasAll(params GameTag[] tags)` – verifica se tutti i tag specificati sono presenti.
+- `List<GameTag> Intersection(params GameTag[] tags)` – restituisce l'intersezione tra i tag presenti e quelli passati.
+- `List<GameTag> Union(params GameTag[] tags)` – restituisce l'unione tra i tag presenti e quelli passati.
+
+Sono inoltre disponibili versioni statiche degli stessi metodi che accettano un'interfaccia `ITaggable` e consentono di effettuare queste operazioni direttamente sulle liste di tag.
 
 ### Esempio di utilizzo
 ```cs

--- a/Runtime/Tag Manager/TagManager.cs
+++ b/Runtime/Tag Manager/TagManager.cs
@@ -33,12 +33,107 @@ namespace GameUtils
             return false;
         }
 
+        public bool HasAll(params GameTag[] tags)
+        {
+            foreach (var tag in tags)
+            {
+                if (!HasAny(tag))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public List<GameTag> Intersection(params GameTag[] tags)
+        {
+            var result = new List<GameTag>();
+            foreach (var tag in tags)
+            {
+                if (HasAny(tag))
+                {
+                    result.Add(tag);
+                }
+            }
+            return result;
+        }
+
+        public List<GameTag> Union(params GameTag[] tags)
+        {
+            var result = new List<GameTag>();
+            foreach (var kvp in _values)
+            {
+                if (kvp.Value.Value > 0)
+                {
+                    result.Add(kvp.Value.Tag);
+                }
+            }
+
+            foreach (var tag in tags)
+            {
+                if (!result.Contains(tag))
+                {
+                    result.Add(tag);
+                }
+            }
+            return result;
+        }
+
         //
         public Dictionary<string, RuntimeTag> GetMap() => _values;
         public bool TryGetValue(string tag, out RuntimeTag runtimeTag) => _values.TryGetValue(tag, out runtimeTag);
         public void SetTagValue(GameTag tag, int value) => _values[tag.ID] = new RuntimeTag { Tag = tag, Value = value };
         private bool HasAny(string tag) => _values.TryGetValue(tag, out RuntimeTag info) && info.Value > 0;
         public bool HasAny(GameTag tag) => HasAny(tag.ID);
+        public static bool HasAny(ITaggable taggable, params GameTag[] tags)
+        {
+            foreach (var tag in tags)
+            {
+                if (taggable.Tags.Contains(tag))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool HasAll(ITaggable taggable, params GameTag[] tags)
+        {
+            foreach (var tag in tags)
+            {
+                if (!taggable.Tags.Contains(tag))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public static List<GameTag> Intersection(ITaggable taggable, params GameTag[] tags)
+        {
+            var result = new List<GameTag>();
+            foreach (var tag in tags)
+            {
+                if (taggable.Tags.Contains(tag))
+                {
+                    result.Add(tag);
+                }
+            }
+            return result;
+        }
+
+        public static List<GameTag> Union(ITaggable taggable, params GameTag[] tags)
+        {
+            var result = new List<GameTag>(taggable.Tags);
+            foreach (var tag in tags)
+            {
+                if (!result.Contains(tag))
+                {
+                    result.Add(tag);
+                }
+            }
+            return result;
+        }
         public void Clear() => _values.Clear();
     }
 }


### PR DESCRIPTION
## Summary
- add HasAll, Intersection, and Union operations to `TagManager`
- expose static set helpers that operate on `ITaggable` implementations
- document new tag utilities

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4992991b0832493d607b9dbc55d1a