### PR TITLE
Fix VitalSystem invulnerability lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added DebugInfo
 - Fixed compilation error in PersistentID
+- Fixed `VitalSystem` permanent and temporary invulnerability state transitions, including duplicate end notifications (3.6.1).
 
 ## 3.6
 

--- a/Runtime/Health/README.md
+++ b/Runtime/Health/README.md
@@ -78,15 +78,19 @@ vitalSystem.Destroy(); // Instantly depletes to minimum
 
 // Invulnerability
 vitalSystem.SetInvulnerable(true, 2f); // Invulnerable for 2 seconds
+vitalSystem.SetInvulnerable(true, 0f); // Invulnerable until explicitly disabled
+vitalSystem.SetInvulnerable(false); // Ends either mode; repeated calls do not emit another end notification
 bool invuln = vitalSystem.IsInvulnerable;
 ```
+
+`IsInvulnerable` reports the active runtime state independently of the temporary duration remaining. Positive durations expire automatically, while zero or negative durations remain active until `SetInvulnerable(false)` is called. Calling `SetInvulnerable(true, duration)` again refreshes the duration without emitting another start notification.
 
 **Virtual Hooks:**
 - `OnDamaged(amount, source)` — Called when damage is successfully applied
 - `OnRestored(amount, source)` — Called when restoration is successful
 - `OnDestroyed()` — Called when vital is destroyed (reaches minimum)
 - `OnInvulnerabilityStarted()` — Called when invulnerability begins
-- `OnInvulnerabilityEnded()` — Called when invulnerability expires
+- `OnInvulnerabilityEnded()` — Called once when invulnerability expires or is manually disabled
 
 **Use Cases:**
 - Player health systems

--- a/Runtime/Health/Systems/VitalSystem.cs
+++ b/Runtime/Health/Systems/VitalSystem.cs
@@ -18,24 +18,44 @@ namespace GameUtils
         [SerializeField, Group("Settings")] protected bool _invulnerable = false;
         [SerializeField, Group("Settings"), ShowIf(nameof(_invulnerable))] protected float _invulnerabilityDuration = 0f;
 
-        private float _invulnerabilityTimer = 0f;
+        private bool _isInvulnerable = false;
+        private float _invulnerabilityTimeRemaining = 0f;
 
         /// <summary>
         /// Returns true if the vital system is currently invulnerable.
         /// </summary>
-        public bool IsInvulnerable => _invulnerable && _invulnerabilityTimer > 0f;
+        public bool IsInvulnerable => _isInvulnerable;
+
+        protected virtual void Awake()
+        {
+            // Copy inspector configuration into runtime state without conflating it with remaining time.
+            _isInvulnerable = _invulnerable;
+            _invulnerabilityTimeRemaining = _isInvulnerable ? Mathf.Max(0f, _invulnerabilityDuration) : 0f;
+        }
 
         protected virtual void Update()
         {
-            // Update invulnerability timer.
-            if (_invulnerable && _invulnerabilityTimer > 0f)
+            // Advance only temporary invulnerability; a zero remainder represents a permanent state.
+            UpdateInvulnerability(Time.deltaTime);
+        }
+
+        /// <summary>
+        /// Advances a temporary invulnerability state by the supplied elapsed time.
+        /// </summary>
+        /// <param name="deltaTime">Elapsed time in seconds.</param>
+        protected void UpdateInvulnerability(float deltaTime)
+        {
+            // Ignore permanent and inactive states so their state cannot end on a later frame.
+            if (!_isInvulnerable || _invulnerabilityTimeRemaining <= 0f)
             {
-                _invulnerabilityTimer -= Time.deltaTime;
-                if (_invulnerabilityTimer <= 0f)
-                {
-                    _invulnerabilityTimer = 0f;
-                    OnInvulnerabilityEnded();
-                }
+                return;
+            }
+
+            _invulnerabilityTimeRemaining -= deltaTime;
+            if (_invulnerabilityTimeRemaining <= 0f)
+            {
+                // End through the shared transition to guarantee a single notification.
+                EndInvulnerability();
             }
         }
 
@@ -113,19 +133,39 @@ namespace GameUtils
         /// <param name="duration">Duration of invulnerability in seconds (0 = permanent).</param>
         public virtual void SetInvulnerable(bool enabled, float duration = 0f)
         {
-            _invulnerable = enabled;
-            _invulnerabilityTimer = enabled ? duration : 0f;
-
             if (enabled)
             {
-                this.Log($"[{nameof(VitalSystem)}] {gameObject.name} became invulnerable for {(duration > 0f ? duration + "s" : "permanent")}.");
-                OnInvulnerabilityStarted();
+                // A repeated enable updates the remaining duration without starting the state twice.
+                _invulnerabilityTimeRemaining = Mathf.Max(0f, duration);
+                if (!_isInvulnerable)
+                {
+                    _isInvulnerable = true;
+                    this.Log($"[{nameof(VitalSystem)}] {gameObject.name} became invulnerable for {(duration > 0f ? duration + "s" : "permanent")}.");
+                    OnInvulnerabilityStarted();
+                }
             }
             else
             {
-                this.Log($"[{nameof(VitalSystem)}] {gameObject.name} is no longer invulnerable.");
-                OnInvulnerabilityEnded();
+                // Use the same guarded transition used by automatic expiration.
+                EndInvulnerability();
             }
+        }
+
+        /// <summary>
+        /// Ends the active invulnerability state and emits its notification once.
+        /// </summary>
+        private void EndInvulnerability()
+        {
+            // Repeated disable or expiration calls are no-ops after the first transition.
+            if (!_isInvulnerable)
+            {
+                return;
+            }
+
+            _isInvulnerable = false;
+            _invulnerabilityTimeRemaining = 0f;
+            this.Log($"[{nameof(VitalSystem)}] {gameObject.name} is no longer invulnerable.");
+            OnInvulnerabilityEnded();
         }
 
         /// <summary>

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1f62971b4c34093a7e47b6439e7a3d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime.meta
+++ b/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c901d97d38945baa9e01ba16f0b82ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/GameUtils.Tests.asmdef
+++ b/Tests/Runtime/GameUtils.Tests.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "GameUtils.Tests",
+    "rootNamespace": "GameUtils.Tests",
+    "references": [
+        "GameUtils"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Runtime/GameUtils.Tests.asmdef.meta
+++ b/Tests/Runtime/GameUtils.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8dec84f6e25f422aaf84a85e0f6124fe
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/VitalSystemTests.cs
+++ b/Tests/Runtime/VitalSystemTests.cs
@@ -1,0 +1,151 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace GameUtils.Tests
+{
+    /// <summary>
+    /// Verifies the runtime transitions of <see cref="VitalSystem"/> invulnerability.
+    /// </summary>
+    public class VitalSystemTests
+    {
+        private GameObject _gameObject;
+        private TestVitalSystem _vitalSystem;
+
+        /// <summary>
+        /// Creates an isolated vital system before every test.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            // Use a real component so the tests exercise the MonoBehaviour implementation.
+            _gameObject = new GameObject(nameof(VitalSystemTests));
+            _vitalSystem = _gameObject.AddComponent<TestVitalSystem>();
+        }
+
+        /// <summary>
+        /// Destroys the test GameObject after every test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            // Destroy immediately because EditMode tests do not advance a player loop.
+            Object.DestroyImmediate(_gameObject);
+        }
+
+        /// <summary>
+        /// Confirms a zero-duration state remains active until explicitly disabled.
+        /// </summary>
+        [Test]
+        public void PermanentInvulnerabilityDoesNotExpire()
+        {
+            // Advance far beyond any plausible temporary duration.
+            _vitalSystem.SetInvulnerable(true, 0f);
+            _vitalSystem.AdvanceInvulnerability(100f);
+            _vitalSystem.TakeDamage(10f);
+
+            Assert.That(_vitalSystem.IsInvulnerable, Is.True);
+            Assert.That(_vitalSystem.EndedCount, Is.Zero);
+            Assert.That(_vitalSystem.DamageApplicationCount, Is.Zero);
+
+            // Damage reaches the vital implementation after explicit deactivation.
+            _vitalSystem.SetInvulnerable(false);
+            _vitalSystem.TakeDamage(10f);
+            Assert.That(_vitalSystem.DamageApplicationCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Confirms a positive-duration state expires exactly once.
+        /// </summary>
+        [Test]
+        public void TemporaryInvulnerabilityExpiresOnce()
+        {
+            // Cross the configured duration and then advance another frame.
+            _vitalSystem.SetInvulnerable(true, 1f);
+            _vitalSystem.AdvanceInvulnerability(0.5f);
+            Assert.That(_vitalSystem.IsInvulnerable, Is.True);
+
+            _vitalSystem.AdvanceInvulnerability(0.5f);
+            _vitalSystem.AdvanceInvulnerability(1f);
+
+            Assert.That(_vitalSystem.IsInvulnerable, Is.False);
+            Assert.That(_vitalSystem.EndedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Confirms manual disabling ends an active temporary state once.
+        /// </summary>
+        [Test]
+        public void ManualDisableCancelsTemporaryInvulnerability()
+        {
+            // Disable before the timer can expire and ensure later updates remain inert.
+            _vitalSystem.SetInvulnerable(true, 10f);
+            _vitalSystem.SetInvulnerable(false);
+            _vitalSystem.AdvanceInvulnerability(10f);
+
+            Assert.That(_vitalSystem.IsInvulnerable, Is.False);
+            Assert.That(_vitalSystem.EndedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Confirms repeated calls do not duplicate lifecycle notifications.
+        /// </summary>
+        [Test]
+        public void RepeatedCallsEmitEachTransitionOnce()
+        {
+            // Refresh the active state and disable it repeatedly.
+            _vitalSystem.SetInvulnerable(true, 1f);
+            _vitalSystem.SetInvulnerable(true, 2f);
+            _vitalSystem.SetInvulnerable(false);
+            _vitalSystem.SetInvulnerable(false);
+
+            Assert.That(_vitalSystem.StartedCount, Is.EqualTo(1));
+            Assert.That(_vitalSystem.EndedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Test seam that exposes deterministic time advancement and hook counts.
+        /// </summary>
+        private sealed class TestVitalSystem : VitalSystem
+        {
+            public int StartedCount { get; private set; }
+            public int EndedCount { get; private set; }
+            public int DamageApplicationCount { get; private set; }
+
+            /// <summary>
+            /// Advances the protected invulnerability timer for an EditMode test.
+            /// </summary>
+            public void AdvanceInvulnerability(float deltaTime)
+            {
+                // Delegate to production timer logic rather than reproducing it in the test.
+                UpdateInvulnerability(deltaTime);
+            }
+
+            /// <summary>
+            /// Records attempts to apply damage after the invulnerability guard.
+            /// </summary>
+            public override void SubtractValue(float amount)
+            {
+                // Avoid requiring attribute assets while still observing the damage path.
+                DamageApplicationCount++;
+            }
+
+            /// <summary>
+            /// Counts invulnerability start transitions.
+            /// </summary>
+            protected override void OnInvulnerabilityStarted()
+            {
+                // Record the hook call for assertions.
+                StartedCount++;
+            }
+
+            /// <summary>
+            /// Counts invulnerability end transitions.
+            /// </summary>
+            protected override void OnInvulnerabilityEnded()
+            {
+                // Record the hook call for assertions.
+                EndedCount++;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/VitalSystemTests.cs.meta
+++ b/Tests/Runtime/VitalSystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2588bac3341d4999856fe4967562b6a6


### PR DESCRIPTION
### Motivation
- Separate the serialized/configured invulnerability settings from the active runtime state and the remaining temporary duration to avoid conflating configuration and runtime behavior.
- Make `SetInvulnerable(true, 0f)` represent permanent invulnerability until `SetInvulnerable(false)` is called, while positive durations still expire automatically.
- Prevent duplicate lifecycle notifications by ensuring `OnInvulnerabilityEnded()` is emitted only once per transition.

### Description
- Introduced a runtime flag `_isInvulnerable` and `_invulnerabilityTimeRemaining` and copied inspector values into runtime state in `Awake()` so configured values no longer equal the active runtime flag.
- Changed `IsInvulnerable` to reflect the runtime state (`_isInvulnerable`) and refactored `Update()` to `UpdateInvulnerability(deltaTime)` to advance temporary timers deterministically.
- Made `SetInvulnerable(bool, float)` idempotent: repeated enables refresh duration without re-emitting start, and disables (manual or automatic expiration) go through `EndInvulnerability()` which guarantees a single end transition and single `OnInvulnerabilityEnded()` notification.
- Updated `Runtime/Health/README.md` documenting permanent vs temporary invulnerability and the idempotent behavior of `SetInvulnerable`.
- Added tests: `Tests/Runtime/VitalSystemTests.cs` with EditMode coverage for permanent invulnerability, temporary expiration, manual disable, and repeated calls; added test assembly definition `Tests/Runtime/GameUtils.Tests.asmdef` and corresponding `.meta` files.
- Recorded the fix in `CHANGELOG.md` under version `3.6.1` matching the `package.json` version.

### Testing
<summary>Automated checks performed in the container</summary>
- Ran `git diff --cached --check` and `git diff --check` to ensure no staged whitespace issues; check passed.
- Validated JSON for `package.json`, runtime asmdef and test asmdef using `python3 -m json.tool`; validation passed.
- Verified `CHANGELOG.md` contains the package version `3.6.1` from `package.json`; check passed.
- Verified all new Unity assets have accompanying `.meta` files; check passed.
- Committed changes and confirmed the working tree status and diff summary; commit succeeded (`Fix VitalSystem invulnerability lifecycle`).
- Note: the Unity Test Runner suite (PlayMode/EditMode test execution) was not executed because Unity Editor is not installed in the container; the new NUnit EditMode tests were added but not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b44252f208324b440965bcf212cae)