### PR TITLE
Fix duplicate VitalSystem destruction notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added DebugInfo
 - Fixed compilation error in PersistentID
+- Fixed duplicate VitalSystem destruction notifications and made repeated `Destroy()` calls idempotent.
+- Added VitalSystem depletion and destruction notification tests.
 
 ## 3.6
 

--- a/Runtime/Health/README.md
+++ b/Runtime/Health/README.md
@@ -88,6 +88,11 @@ bool invuln = vitalSystem.IsInvulnerable;
 - `OnInvulnerabilityStarted()` — Called when invulnerability begins
 - `OnInvulnerabilityEnded()` — Called when invulnerability expires
 
+**Destruction semantics:**
+- Destruction notifications are emitted only when the vital actually transitions from a value above its minimum to the minimum.
+- `Destroy()` delegates to `SetToMin()` and is idempotent while the vital is already depleted; calls made at the minimum do not emit `OnDestroyed` or the configured `On Destroyed` event again.
+- Restoring the vital above its minimum permits a later depletion to emit a new destruction notification.
+
 **Use Cases:**
 - Player health systems
 - Enemy health bars

--- a/Runtime/Health/Systems/VitalSystem.cs
+++ b/Runtime/Health/Systems/VitalSystem.cs
@@ -100,10 +100,15 @@ namespace GameUtils
         /// </summary>
         public virtual void Destroy()
         {
+            // Delegate destruction to the value transition so depletion has one notification path.
+            if (IsAtMin)
+            {
+                this.Log($"[{nameof(VitalSystem)}] Destroy ignored: {gameObject.name} is already at its minimum value.");
+                return;
+            }
+
             this.Log($"[{nameof(VitalSystem)}] {gameObject.name} destroyed.");
             SetToMin();
-            OnDestroyed();
-            _onDestroyed?.Invoke();
         }
 
         /// <summary>
@@ -156,7 +161,7 @@ namespace GameUtils
         protected override void OnMinReached()
         {
             base.OnMinReached();
-            // Automatically trigger destruction when depleted.
+            // Emit destruction only for the actual transition from above minimum to minimum.
             OnDestroyed();
             _onDestroyed?.Invoke();
         }

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 831ca2b5ff2c4f95af9320bee4c4eca7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime.meta
+++ b/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 975f17e1800e4c1899bcbf5edbabf011
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/GameUtils.Runtime.Tests.asmdef
+++ b/Tests/Runtime/GameUtils.Runtime.Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "GameUtils.Runtime.Tests",
+    "rootNamespace": "GameUtils.Tests",
+    "references": [
+        "GameUtils"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Runtime/GameUtils.Runtime.Tests.asmdef.meta
+++ b/Tests/Runtime/GameUtils.Runtime.Tests.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69438acf5f5149cfa63850166dc9f36d

--- a/Tests/Runtime/TestVitalSystem.cs
+++ b/Tests/Runtime/TestVitalSystem.cs
@@ -1,0 +1,24 @@
+namespace GameUtils.Tests
+{
+    /// <summary>
+    /// Exposes VitalSystem dependencies and notifications for focused tests.
+    /// </summary>
+    public sealed class TestVitalSystem : VitalSystem
+    {
+        public int DestroyedHookCount { get; private set; }
+
+        public void Configure(RuntimeVital vital, VoidEventAsset destroyedEvent)
+        {
+            // Inject runtime dependencies without relying on MonoBehaviour lifecycle setup.
+            _vital = vital;
+            _onDestroyed = destroyedEvent;
+            _logEnabled = false;
+        }
+
+        protected override void OnDestroyed()
+        {
+            // Count the protected destruction hook for assertions.
+            DestroyedHookCount++;
+        }
+    }
+}

--- a/Tests/Runtime/TestVitalSystem.cs.meta
+++ b/Tests/Runtime/TestVitalSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36f05b58394b4a73a89cdb9d2a51c586

--- a/Tests/Runtime/VitalSystemTests.cs
+++ b/Tests/Runtime/VitalSystemTests.cs
@@ -1,0 +1,93 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace GameUtils.Tests
+{
+    /// <summary>
+    /// Verifies that vital depletion emits destruction notifications once per transition.
+    /// </summary>
+    public class VitalSystemTests
+    {
+        private GameObject _gameObject;
+        private TestVitalSystem _system;
+        private AttributeData _attributeData;
+        private VoidEventAsset _destroyedEvent;
+        private int _assetNotificationCount;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Build an isolated vital and subscribe to both destruction notification paths.
+            _gameObject = new GameObject(nameof(VitalSystemTests));
+            _system = _gameObject.AddComponent<TestVitalSystem>();
+            _attributeData = ScriptableObject.CreateInstance<AttributeData>();
+            JsonUtility.FromJsonOverwrite("{\"_minValue\":0,\"_maxValue\":100,\"_isVital\":true}", _attributeData);
+            _destroyedEvent = ScriptableObject.CreateInstance<VoidEventAsset>();
+            _destroyedEvent.AddListener(_system, CountAssetNotification);
+            _system.Configure(new RuntimeVital(null, _attributeData, 100f), _destroyedEvent);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Release Unity objects created for each test.
+            Object.DestroyImmediate(_destroyedEvent);
+            Object.DestroyImmediate(_attributeData);
+            Object.DestroyImmediate(_gameObject);
+        }
+
+        [Test]
+        public void LethalDamage_NotifiesOnce()
+        {
+            // Lethal damage must notify through the minimum transition only.
+            _system.TakeDamage(100f);
+
+            AssertDestroyedOnce();
+        }
+
+        [Test]
+        public void Destroy_FromFullValue_NotifiesOnce()
+        {
+            // Explicit destruction must delegate to the same minimum transition.
+            _system.Destroy();
+
+            AssertDestroyedOnce();
+        }
+
+        [Test]
+        public void Destroy_WhenAlreadyDepleted_DoesNotNotifyAgain()
+        {
+            // A vital already depleted by damage must treat destruction as a no-op.
+            _system.TakeDamage(100f);
+            _system.Destroy();
+
+            AssertDestroyedOnce();
+        }
+
+        [Test]
+        public void RepeatedDestroyCalls_DoNotDuplicateNotifications()
+        {
+            // Repeated commands must remain idempotent after the first transition.
+            _system.Destroy();
+            _system.Destroy();
+            _system.Destroy();
+
+            AssertDestroyedOnce();
+        }
+
+        private void CountAssetNotification()
+        {
+            // Track ScriptableObject event emissions separately from the virtual hook.
+            _assetNotificationCount++;
+        }
+
+        private void AssertDestroyedOnce()
+        {
+            // Both public notification mechanisms must agree on exactly one emission.
+            Assert.That(_system.DestroyedHookCount, Is.EqualTo(1));
+            Assert.That(_assetNotificationCount, Is.EqualTo(1));
+            Assert.That(_system.IsAtMin, Is.True);
+        }
+
+    }
+}

--- a/Tests/Runtime/VitalSystemTests.cs.meta
+++ b/Tests/Runtime/VitalSystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e353c527686641e29653f8f80cdd76c5


### PR DESCRIPTION
<summary>
Centralize destruction notifications on the actual transition to minimum value and make `Destroy()` idempotent when the vital is already depleted.
</summary>

### Motivation
- Ensure a single authoritative path emits `OnDestroyed()` and `_onDestroyed` when a vital reaches its minimum so consumers receive one consistent notification.  
- Prevent duplicate notifications caused by both explicit `Destroy()` and the min-value transition firing the same events.  
- Provide deterministic behavior for `Destroy()` when called on an already-depleted vital and add tests to guard regressions.  

### Description
- Changed `VitalSystem.Destroy()` to delegate to the value transition and return early if the vital `IsAtMin`, logging the no-op case and calling only `SetToMin()` otherwise (removed direct `OnDestroyed()`/`_onDestroyed?.Invoke()` from `Destroy()`).  
- Kept emission of destruction notifications in `OnMinReached()` so the notification only occurs on the actual transition to the minimum (`OnDestroyed()` and `_onDestroyed?.Invoke()`).  
- Added Edit Mode tests under `Tests/Runtime`: `GameUtils.Runtime.Tests` asmdef, `VitalSystemTests.cs` and `TestVitalSystem.cs` to cover lethal damage, `Destroy()` from full value, `Destroy()` when already depleted, and repeated `Destroy()` calls.  
- Documented the semantics in `Runtime/Health/README.md` and recorded the change in `CHANGELOG.md` for package version `3.6.1`.  

### Testing
- Ran `git diff --check` and static repository checks, which reported no issues.  
- Validated the new test assembly definition JSON by loading the `Tests/Runtime/GameUtils.Runtime.Tests.asmdef` file and checked Unity asset/meta pairings, both succeeded.  
- NUnit Edit Mode tests could not be executed in this container because the Unity Test Runner is not available here, so the new tests were added but not run locally in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b44265cbc832490879dce92d7e023)