### PR TITLE
Fire OnDepleted on transition to minimum; add tests and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added DebugInfo
 - Fixed compilation error in PersistentID
+- Fixed `RegeneratingVitalSystem` depletion notifications so its event asset and protected hook fire once when the vital transitions to its minimum value.
+- Added `RegeneratingVitalSystem` consumption tests for partial, exact, excessive, and already-depleted consumption.
 
 ## 3.6
 

--- a/Runtime/Health/README.md
+++ b/Runtime/Health/README.md
@@ -113,7 +113,7 @@ Generic regenerating vital system for attributes like **mana, stamina, energy, s
   - `On Restored` — `GameEventAsset<float, object>` invoked when vital is restored (amount, source)
   - `On Regen Started` — `VoidEventAsset` invoked when regeneration begins
   - `On Regen Stopped` — `VoidEventAsset` invoked when regeneration stops
-  - `On Depleted` — `VoidEventAsset` invoked when vital reaches zero
+  - `On Depleted` — `VoidEventAsset` invoked once when the vital transitions to its minimum value
 - **Regeneration Settings** group:
   - `Auto Regenerate` — Enable automatic regeneration over time
   - `Regen Rate` — Amount regenerated per second
@@ -138,6 +138,7 @@ bool isRegen = regenSystem.IsRegenerating;
 - `OnRestored(amount, source)` — Called when restoration is successful
 - `OnRegenStarted()` — Called when regeneration begins
 - `OnRegenStopped()` — Called when regeneration stops
+- `OnDepleted()` — Called once when the vital transitions to its minimum value
 - `RegenerateCoroutine()` — Override to customize regeneration behavior
 
 **Use Cases:**

--- a/Runtime/Health/Systems/RegeneratingVitalSystem.cs
+++ b/Runtime/Health/Systems/RegeneratingVitalSystem.cs
@@ -199,9 +199,18 @@ namespace GameUtils
         /// </summary>
         protected virtual void OnRegenStopped() { }
 
+        /// <summary>
+        /// Called when the vital transitions to its minimum value.
+        /// </summary>
+        protected virtual void OnDepleted() { }
+
         protected override void OnMinReached()
         {
             base.OnMinReached();
+            // Notify both extension points once for the transition detected by BaseVitalSystem.
+            OnDepleted();
+            _onDepleted?.Invoke();
+
             // Stop regeneration when depleted, will restart after delay.
             StopRegeneration();
             _timeSinceLastConsumption = 0f;

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec50cfacfe1645249fa4440eea8b1f0d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime.meta
+++ b/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c60565ef934c4351845bb2e57814253a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/GameUtils.Runtime.Tests.asmdef
+++ b/Tests/Runtime/GameUtils.Runtime.Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "GameUtils.Runtime.Tests",
+    "rootNamespace": "GameUtils.Tests",
+    "references": [
+        "GameUtils"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Runtime/GameUtils.Runtime.Tests.asmdef.meta
+++ b/Tests/Runtime/GameUtils.Runtime.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95fb5ab3b0d94e6da5bdfd87f18196f4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/RegeneratingVitalSystemTests.cs
+++ b/Tests/Runtime/RegeneratingVitalSystemTests.cs
@@ -1,0 +1,124 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace GameUtils.Tests
+{
+    public class RegeneratingVitalSystemTests
+    {
+        private GameObject _gameObject;
+        private TestRegeneratingVitalSystem _system;
+        private AttributeData _attributeData;
+        private VoidEventAsset _depletedEvent;
+        private int _assetInvocationCount;
+
+        /// <summary>
+        /// Creates an initialized vital system and observes its depletion event asset.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            _gameObject = new GameObject(nameof(RegeneratingVitalSystemTests));
+            _system = _gameObject.AddComponent<TestRegeneratingVitalSystem>();
+            _attributeData = ScriptableObject.CreateInstance<AttributeData>();
+            _depletedEvent = ScriptableObject.CreateInstance<VoidEventAsset>();
+            _depletedEvent.AddListener(_system, OnDepletedAssetInvoked);
+            _system.Configure(new RuntimeVital(null, _attributeData, 10f), _depletedEvent);
+        }
+
+        /// <summary>
+        /// Releases all Unity objects created by a test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_depletedEvent);
+            Object.DestroyImmediate(_attributeData);
+            Object.DestroyImmediate(_gameObject);
+        }
+
+        /// <summary>
+        /// Verifies partial consumption does not report depletion.
+        /// </summary>
+        [Test]
+        public void Consume_PartialAmount_DoesNotInvokeDepletedNotifications()
+        {
+            _system.Consume(4f);
+
+            Assert.That(_system.CurrentValue, Is.EqualTo(6f));
+            Assert.That(_system.DepletedHookInvocationCount, Is.Zero);
+            Assert.That(_assetInvocationCount, Is.Zero);
+        }
+
+        /// <summary>
+        /// Verifies exact consumption reports the transition to the minimum.
+        /// </summary>
+        [Test]
+        public void Consume_AmountToMinimum_InvokesDepletedNotificationsOnce()
+        {
+            _system.Consume(10f);
+
+            Assert.That(_system.CurrentValue, Is.EqualTo(_system.MinValue));
+            Assert.That(_system.DepletedHookInvocationCount, Is.EqualTo(1));
+            Assert.That(_assetInvocationCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies excessive consumption is clamped and reports one depletion transition.
+        /// </summary>
+        [Test]
+        public void Consume_AmountBeyondMinimum_InvokesDepletedNotificationsOnce()
+        {
+            _system.Consume(15f);
+
+            Assert.That(_system.CurrentValue, Is.EqualTo(_system.MinValue));
+            Assert.That(_system.DepletedHookInvocationCount, Is.EqualTo(1));
+            Assert.That(_assetInvocationCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies consumption attempts while already depleted do not repeat notifications.
+        /// </summary>
+        [Test]
+        public void Consume_WhenAlreadyDepleted_DoesNotRepeatDepletedNotifications()
+        {
+            _system.Consume(10f);
+            _system.Consume(1f);
+            _system.Consume(5f);
+
+            Assert.That(_system.CurrentValue, Is.EqualTo(_system.MinValue));
+            Assert.That(_system.DepletedHookInvocationCount, Is.EqualTo(1));
+            Assert.That(_assetInvocationCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Counts invocations emitted through the configured event asset.
+        /// </summary>
+        private void OnDepletedAssetInvoked()
+        {
+            _assetInvocationCount++;
+        }
+
+        private sealed class TestRegeneratingVitalSystem : RegeneratingVitalSystem
+        {
+            public int DepletedHookInvocationCount { get; private set; }
+
+            /// <summary>
+            /// Injects the test vital and event asset without requiring scene data.
+            /// </summary>
+            public void Configure(RuntimeVital vital, VoidEventAsset depletedEvent)
+            {
+                _vital = vital;
+                _onDepleted = depletedEvent;
+                _logEnabled = false;
+            }
+
+            /// <summary>
+            /// Records calls to the protected depletion extension point.
+            /// </summary>
+            protected override void OnDepleted()
+            {
+                DepletedHookInvocationCount++;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/RegeneratingVitalSystemTests.cs.meta
+++ b/Tests/Runtime/RegeneratingVitalSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0c58ca082b94fa48b11d50a46e82c10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Motivation
- <summary>Ensure depletion notifications represent the transition to the minimum value and are not repeated when already depleted.</summary>
- Add a protected hook consistent with other system events so subclasses can react to depletion via `OnDepleted()`.
- Provide automated edit-mode tests to validate consumption edge cases and document the behavior in README and `CHANGELOG.md`.

### Description
- Added a protected `OnDepleted()` virtual hook to `RegeneratingVitalSystem` and invoke it together with the `_onDepleted` asset from `OnMinReached()` so notifications fire once on the actual transition to minimum, not on repeated consumption calls. (`Runtime/Health/Systems/RegeneratingVitalSystem.cs`)
- Updated `Runtime/Health/README.md` to clarify that `On Depleted` / `OnDepleted()` represent a single transition to the minimum value. (`Runtime/Health/README.md`)
- Added edit-mode test assembly and `RegeneratingVitalSystemTests` with tests for partial consumption, exact-to-minimum, beyond-minimum, and repeated consumption when already depleted. (`Tests/Runtime/RegeneratingVitalSystemTests.cs` and test asmdef files)
- Updated `CHANGELOG.md` (version `3.6.1`) with the fix and the added tests. (`CHANGELOG.md`)

### Testing
- Ran `git diff --check` to validate repository cleanliness which passed before committing. 
- Validated the newly added test asmdef with `python3 -m json.tool Tests/Runtime/GameUtils.Runtime.Tests.asmdef` which passed. 
- Committed the changes successfully (commit `4ec5763`), and added test assets and metadata files.
- Unity Test Runner could not be executed in this environment, so the new edit-mode tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b442698708324af2e42903d42946a)